### PR TITLE
Feature: Add android support and initial docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,15 +16,15 @@ npx expo install react-native-passkeys
 
 #### 1. Host an Apple App Site Association (AASA) file
 
-For Passkeys to work on iOS, you'll need to host an AASA file on your domain. This file is used to verify that your app is allowed to handle the domain you are trying to authenticate with.
+For Passkeys to work on iOS, you'll need to host an AASA file on your domain. This file is used to verify that your app is allowed to handle the domain you are trying to authenticate with. This must be hosted on a site with a valid SSL certificate.
 
-The file should be hosted at (note there is no `.json` extension):
+The file should be hosted at:
 
 ```
 https://<your_domain>/.well-known/apple-app-site-association
 ```
 
-and should look something like this:
+Note there is no `.json` extension for this file but the format is json. The contents of the file should look something like this:
 
 ```json
 {
@@ -33,6 +33,8 @@ and should look something like this:
   }
 }
 ```
+
+Replace `<teamID>` with your Apple Team ID and `<bundleID>` with your app's bundle identifier.
 
 #### 2. Add Associated Domains
 
@@ -54,14 +56,14 @@ Replace `<your_domain>` with the domain you are hosting the AASA file on. For ex
 
 ```sh
 npx expo prebuild -p ios
-npx expo run:ios
+npx expo run:ios # or build in the cloud with EAS
 ```
 
 ## Android Setup
 
 #### 1. Host an `assetlinks.json` File
 
-For Passkeys to work on Android, you'll need to host an `assetlinks.json` file on your domain. This file is used to verify that your app is allowed to handle the domain you are trying to authenticate with.
+For Passkeys to work on Android, you'll need to host an `assetlinks.json` file on your domain. This file is used to verify that your app is allowed to handle the domain you are trying to authenticate with. This must be hosted on a site with a valid SSL certificate.
 
 The file should be hosted at:
 
@@ -111,5 +113,5 @@ Next, you'll need to modify the `compileSdkVersion` in your `app.json` to be at 
 
 ```sh
 npx expo prebuild -p android
-npx expo run:android
+npx expo run:android # or build in the cloud with EAS
 ```

--- a/README.md
+++ b/README.md
@@ -1,7 +1,115 @@
 # React Native Passkeys
 
-This is a module to help you create and authenticate with passkeys on ios, android & web with the same api. The library aims to stay close to the standard [`navigator.credentials`](https://w3c.github.io/webappsec-credential-management/#framework-credential-management). More specifically, we provide an api for `get` & `create` functions (since these are the functions available cross-platform).
+This is an Expo module to help you create and authenticate with passkeys on iOS, Android & web with the same api. The library aims to stay close to the standard [`navigator.credentials`](https://w3c.github.io/webappsec-credential-management/#framework-credential-management). More specifically, we provide an api for `get` & `create` functions (since these are the functions available cross-platform).
 
 The adaptations we make are simple niceties like providing automatic conversion of base64-url encoded strings to buffer. This is also done to make it easier to pass the values to the native side.
 
 Further niceties include some flag functions that indicate support for certain features.
+
+## Installation
+
+```sh
+npx expo install react-native-passkeys
+```
+
+## iOS Setup
+
+#### 1. Host an Apple App Site Association (AASA) file
+
+For Passkeys to work on iOS, you'll need to host an AASA file on your domain. This file is used to verify that your app is allowed to handle the domain you are trying to authenticate with.
+
+The file should be hosted at (note there is no `.json` extension):
+
+```
+https://<your_domain>/.well-known/apple-app-site-association
+```
+
+and should look something like this:
+
+```json
+{
+  "webcredentials": {
+    "apps": ["<teamID>.<bundleID>"]
+  }
+}
+```
+
+#### 2. Add Associated Domains
+
+Add the following to your `app.json`:
+
+```json
+{
+  "expo": {
+    "ios": {
+      "associatedDomains": ["webcredentials:<your_domain>"]
+    }
+  }
+}
+```
+
+Replace `<your_domain>` with the domain you are hosting the AASA file on. For example, if you are hosting the AASA file on `https://example.com/.well-known/apple-app-site-association`, you would add `example.com` to the `associatedDomains` array.
+
+#### 3. Prebuild and run your app
+
+```sh
+npx expo prebuild -p ios
+npx expo run:ios
+```
+
+## Android Setup
+
+#### 1. Host an `assetlinks.json` File
+
+For Passkeys to work on Android, you'll need to host an `assetlinks.json` file on your domain. This file is used to verify that your app is allowed to handle the domain you are trying to authenticate with.
+
+The file should be hosted at:
+
+```
+https://<your_domain>/.well-known/assetlinks.json
+```
+
+and should look something like this:
+
+```json
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "<package_name>",
+      "sha256_cert_fingerprints": ["<sha256_cert_fingerprint>"]
+    }
+  }
+]
+```
+
+Replace `<package_name>` with your app's package name and `<sha256_cert_fingerprint>` with your app's SHA256 certificate fingerprint.
+
+#### 2. Modify Expo Build Properties
+
+Next, you'll need to modify the `compileSdkVersion` in your `app.json` to be at least 34.
+
+```json
+{
+  "expo": {
+    "plugins": [
+      [
+        "expo-build-properties",
+        {
+          "android": {
+            "compileSdkVersion": 34
+          }
+        }
+      ]
+    ]
+  }
+}
+```
+
+#### 3. Prebuild and run your app
+
+```sh
+npx expo prebuild -p android
+npx expo run:android
+```

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -86,4 +86,7 @@ repositories {
 dependencies {
   implementation project(':expo-modules-core')
   implementation "org.jetbrains.kotlin:kotlin-stdlib-jdk7:${getKotlinVersion()}"
+  implementation "androidx.credentials:credentials:1.3.0-alpha01"
+  implementation "androidx.credentials:credentials-play-services-auth:1.3.0-alpha01"
+  implementation "com.google.code.gson:gson:2.8.9"
 }

--- a/android/src/main/java/expo/modules/passkeys/PasskeyExceptions.kt
+++ b/android/src/main/java/expo/modules/passkeys/PasskeyExceptions.kt
@@ -1,5 +1,0 @@
-package expo.modules.crypto
-
-import expo.modules.kotlin.records.Field
-import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.Enumerable

--- a/android/src/main/java/expo/modules/passkeys/PasskeyOptions.kt
+++ b/android/src/main/java/expo/modules/passkeys/PasskeyOptions.kt
@@ -1,61 +1,239 @@
-package expo.modules.crypto
-
 import expo.modules.kotlin.records.Field
 import expo.modules.kotlin.records.Record
-import expo.modules.kotlin.types.Enumerable
 
-fun handlePasskeyException(exception: Either<GetCredentialException, CreateCredentialException>): String {
-  exception.get(GetCredentialException::class).let {
-     when (e) {
-      is GetPublicKeyCredentialDomException -> {
-        return e.domError.toString()
-      }
-      is GetCredentialCancellationException -> {
-        return "UserCancelled"
-      }
-      is GetCredentialInterruptedException -> {
-        return "Interrupted"
-      }
-      is GetCredentialProviderConfigurationException -> {
-        return "NotConfigured"
-      }
-      is GetCredentialUnknownException -> {
-        return "UnknownError"
-      }
-      is GetCredentialUnsupportedException -> {
-        return "NotSupported"
-      }
-      is NoCredentialException -> {
-        return "NoCredentials"
-      }
-      else -> {
-        return e.toString()
-      }
-    }
-  }
-  exception.get(CreateCredentialException::class).let {
-    when (e) {
-          is CreatePublicKeyCredentialDomException -> {
-            return e.domError.toString()
-          }
-          is CreateCredentialCancellationException -> {
-            return "UserCancelled"
-          }
-          is CreateCredentialInterruptedException -> {
-            return "Interrupted"
-          }
-          is CreateCredentialProviderConfigurationException -> {
-            return "NotConfigured"
-          }
-          is CreateCredentialUnknownException -> {
-            return "UnknownError"
-          }
-          is CreateCredentialUnsupportedException -> {
-            return "NotSupported"
-          }
-          else -> {
-            return e.toString()
-          }
-        }
-  }
+
+/**
+navigator.credentials.get request options
+
+Specification reference: https://w3c.github.io/webauthn/#dictionary-assertion-options
+ */
+class PublicKeyCredentialCreationOptions: Record {
+
+    @Field
+    var rp: PublicKeyCredentialRpEntity = PublicKeyCredentialRpEntity()
+
+    @Field
+    var user: PublicKeyCredentialUserEntity = PublicKeyCredentialUserEntity()
+
+    @Field
+    var challenge: String = ""
+
+    @Field
+    var pubKeyCredParams: List<PublicKeyCredentialParameters> = listOf()
+
+    @Field
+    var timeout: Int? = null
+
+    @Field
+    var excludeCredentials: List<PublicKeyCredentialDescriptor>? = null
+
+    @Field
+    var authenticatorSelection: AuthenticatorSelectionCriteria? = null
+
+    @Field
+    var attestation: String? = null
+
 }
+
+class AuthenticatorSelectionCriteria: Record {
+
+    @Field
+    var authenticatorAttachment: String? = null
+
+    @Field
+    var residentKey: String? = null
+
+    @Field
+    var requireResidentKey: Boolean? = null
+
+    @Field
+    var userVerification: String? = null
+}
+
+class PublicKeyCredentialParameters: Record {
+    @Field
+    var type: String = ""
+
+    @Field
+    var alg: Long = 0
+}
+
+/**
+navigator.credentials.get request options
+
+Specification reference: https://w3c.github.io/webauthn/#dictionary-assertion-options
+ */
+class PublicKeyCredentialRequestOptions: Record {
+    @Field
+    var challenge: String = ""
+
+    @Field
+    var rpId: String = ""
+
+    // TODO: implement the timeout
+    @Field
+    var timeout: Int? = null
+
+    @Field
+    var allowCredentials: List<PublicKeyCredentialParameters>? = null
+
+    @Field
+    var userVerification: String? = null
+}
+
+class PublicKeyCredentialRpEntity: Record {
+
+    @Field
+    var name: String = ""
+
+    @Field
+    var id: String? = null
+}
+
+/**
+Specification reference: https://w3c.github.io/webauthn/#dictdef-publickeycredentialuserentity
+ */
+class PublicKeyCredentialUserEntity: Record {
+
+    @Field
+    var name: String = ""
+
+    @Field
+    var displayName: String = ""
+
+    @Field
+    var id: String = ""
+}
+
+
+/**
+Specification reference: https://w3c.github.io/webauthn/#dictdef-publickeycredentialdescriptor
+ */
+class PublicKeyCredentialDescriptor: Record {
+
+    @Field
+    var id: String = ""
+
+    @Field
+    var transports: List<String>? = null
+
+    @Field
+    var type: String = "public-key"
+}
+
+class RegistrationResponseJSON: Record {
+    @Field
+    var id: String = ""
+
+    @Field
+    var rawId: String = ""
+
+    @Field
+    var response: AuthenticatorAttestationResponseJSON = AuthenticatorAttestationResponseJSON()
+
+    @Field
+    var authenticatorAttachment: String? = null
+
+    @Field
+    var clientExtensionResults: AuthenticationExtensionsClientOutputsJSON? = null
+
+    @Field
+    var type: String = "public-key"
+}
+
+/**
+Specification reference: https://w3c.github.io/webauthn/#dictdef-authenticatorattestationresponsejson
+ */
+class AuthenticatorAttestationResponseJSON: Record {
+
+    @Field
+    var clientDataJSON: String = ""
+
+    // - Required in L3 but not in L2 so leaving optional as most have not adapted L3 yet
+    @Field
+    var authenticatorData: String? = null
+
+    // - Required in L3 but not in L2 so leaving optional as most have not adapted L3 yet
+    @Field
+    var transports: List<String>? = null
+
+    @Field
+    var publicKeyAlgorithm: Int? = null
+
+    @Field
+    var publicKey: String? = null
+
+    @Field
+    var attestationObject: String = ""
+}
+
+/**
+Specification reference: https://w3c.github.io/webauthn/#dictdef-authenticationresponsejson
+ */
+class AuthenticationResponseJSON: Record {
+
+    @Field
+    var type: String = "public-key"
+
+    // - base64URL version of rawId
+    @Field
+    var id: String = ""
+
+    @Field
+    var rawId: String? = null
+
+    @Field
+    var authenticatorAttachment: String? = null
+
+    @Field
+    var response: AuthenticatorAssertionResponseJSON = AuthenticatorAssertionResponseJSON()
+
+    @Field
+    var clientExtensionResults: AuthenticationExtensionsClientOutputsJSON? = null
+}
+
+
+class AuthenticatorAssertionResponseJSON: Record {
+
+    @Field
+    var authenticatorData: String = ""
+
+    @Field
+    var clientDataJSON: String = ""
+
+    @Field
+    var signature: String = ""
+
+    @Field
+    var userHandle: String? = null
+
+    @Field
+    var attestationObject: String? = null
+
+}
+
+class AuthenticationExtensionsClientOutputsJSON: Record {
+
+    // ? this is only available in iOS 17 but I cannot set this here
+    // @available(iOS 17.0, *)
+    @Field
+    var largeBlob: AuthenticationExtensionsLargeBlobOutputsJSON? = null
+
+}
+/**
+We convert this to `AuthenticationExtensionsLargeBlobOutputsJSON` instead of `AuthenticationExtensionsLargeBlobOutputs` for consistency
+and because it is what is actually returned to RN
+
+Specification reference: https://w3c.github.io/webauthn/#dictdef-authenticationextensionslargebloboutputs
+ */
+class AuthenticationExtensionsLargeBlobOutputsJSON: Record {
+
+    @Field
+    var supported: Boolean? = null;
+
+    @Field
+    var blob: String? = null;
+
+    @Field
+    var written: Boolean? = null;
+};

--- a/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
+++ b/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
@@ -8,6 +8,21 @@ import androidx.credentials.CreatePublicKeyCredentialRequest
 import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
+import androidx.credentials.exceptions.CreateCredentialCancellationException
+import androidx.credentials.exceptions.CreateCredentialException
+import androidx.credentials.exceptions.CreateCredentialInterruptedException
+import androidx.credentials.exceptions.CreateCredentialProviderConfigurationException
+import androidx.credentials.exceptions.CreateCredentialUnknownException
+import androidx.credentials.exceptions.CreateCredentialUnsupportedException
+import androidx.credentials.exceptions.GetCredentialCancellationException
+import androidx.credentials.exceptions.GetCredentialException
+import androidx.credentials.exceptions.GetCredentialInterruptedException
+import androidx.credentials.exceptions.GetCredentialProviderConfigurationException
+import androidx.credentials.exceptions.GetCredentialUnknownException
+import androidx.credentials.exceptions.GetCredentialUnsupportedException
+import androidx.credentials.exceptions.NoCredentialException
+import androidx.credentials.exceptions.publickeycredential.CreatePublicKeyCredentialDomException
+import androidx.credentials.exceptions.publickeycredential.GetPublicKeyCredentialDomException
 import com.google.gson.Gson
 import expo.modules.kotlin.Promise
 import expo.modules.kotlin.modules.Module
@@ -34,9 +49,11 @@ class ReactNativePasskeysModule : Module() {
         }
 
         AsyncFunction("create") { request: PublicKeyCredentialCreationOptions, promise: Promise ->
-            val credentialManager = CredentialManager.create(appContext.reactContext?.applicationContext!!)
+            val credentialManager =
+                CredentialManager.create(appContext.reactContext?.applicationContext!!)
             val json = Gson().toJson(request)
             val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(json)
+
 
             mainScope.launch {
                 try {
@@ -45,32 +62,101 @@ class ReactNativePasskeysModule : Module() {
                     }
                     val response =
                         result?.data?.getString("androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON")
-                    val createCredentialResponse = Gson().fromJson(response, RegistrationResponseJSON::class.java)
+                    val createCredentialResponse =
+                        Gson().fromJson(response, RegistrationResponseJSON::class.java)
                     promise.resolve(createCredentialResponse)
-                } catch (e: expo.modules.kotlin.exception.CodedException) {
-                    promise.reject(e)
+                } catch (e: CreateCredentialException) {
+                    promise.reject("Passkey Create", getRegistrationException(e), e)
                 }
             }
         }
 
         AsyncFunction("get") { request: PublicKeyCredentialRequestOptions, promise: Promise ->
-            val credentialManager = CredentialManager.create(appContext.reactContext?.applicationContext!!)
+            val credentialManager =
+                CredentialManager.create(appContext.reactContext?.applicationContext!!)
             val json = Gson().toJson(request)
-            val getCredentialRequest = GetCredentialRequest(listOf(GetPublicKeyCredentialOption(json)))
+            val getCredentialRequest =
+                GetCredentialRequest(listOf(GetPublicKeyCredentialOption(json)))
 
             mainScope.launch {
                 try {
                     val result = appContext.currentActivity?.let {
-                            credentialManager.getCredential(it, getCredentialRequest)
+                        credentialManager.getCredential(it, getCredentialRequest)
                     }
                     val response =
                         result?.credential?.data?.getString("androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON")
-                    val createCredentialResponse = Gson().fromJson(response, AuthenticationResponseJSON::class.java)
+                    val createCredentialResponse =
+                        Gson().fromJson(response, AuthenticationResponseJSON::class.java)
                     promise.resolve(createCredentialResponse)
-                } catch (e: expo.modules.kotlin.exception.CodedException) {
-                    promise.reject(e)
+                } catch (e: GetCredentialException) {
+                    promise.reject("Passkey Get", getAuthenticationException(e), e)
                 }
             }
         }
     }
+
+    private fun getRegistrationException(e: CreateCredentialException) =
+        when (e) {
+            is CreatePublicKeyCredentialDomException -> {
+                e.domError.toString()
+            }
+
+            is CreateCredentialCancellationException -> {
+                "UserCancelled"
+            }
+
+            is CreateCredentialInterruptedException -> {
+                "Interrupted"
+            }
+
+            is CreateCredentialProviderConfigurationException -> {
+                "NotConfigured"
+            }
+
+            is CreateCredentialUnknownException -> {
+                "UnknownError"
+            }
+
+            is CreateCredentialUnsupportedException -> {
+                "NotSupported"
+            }
+
+            else -> e.toString()
+        }
+
+    private fun getAuthenticationException(e: GetCredentialException) =
+        when (e) {
+            is GetPublicKeyCredentialDomException -> {
+                e.domError.toString()
+            }
+
+            is GetCredentialCancellationException -> {
+                "UserCancelled"
+            }
+
+            is GetCredentialInterruptedException -> {
+                "Interrupted"
+            }
+
+            is GetCredentialProviderConfigurationException -> {
+                "NotConfigured"
+            }
+
+            is GetCredentialUnknownException -> {
+                "UnknownError"
+            }
+
+            is GetCredentialUnsupportedException -> {
+                "NotSupported"
+            }
+
+            is NoCredentialException -> {
+                "NoCredentials"
+            }
+
+            else -> {
+                e.toString()
+            }
+        }
+
 }

--- a/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
+++ b/android/src/main/java/expo/modules/passkeys/ReactNativePasskeysModule.kt
@@ -1,55 +1,76 @@
 package expo.modules.passkeys
 
-import expo.modules.kotlin.modules.Module
-import expo.modules.kotlin.modules.ModuleDefinition
-
-import androidx.credentials.CredentialManager
+import AuthenticationResponseJSON
+import PublicKeyCredentialCreationOptions
+import PublicKeyCredentialRequestOptions
+import RegistrationResponseJSON
 import androidx.credentials.CreatePublicKeyCredentialRequest
+import androidx.credentials.CredentialManager
 import androidx.credentials.GetCredentialRequest
 import androidx.credentials.GetPublicKeyCredentialOption
-
+import com.google.gson.Gson
+import expo.modules.kotlin.Promise
+import expo.modules.kotlin.modules.Module
+import expo.modules.kotlin.modules.ModuleDefinition
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.Dispatchers
+import kotlinx.coroutines.launch
 
 class ReactNativePasskeysModule : Module() {
-  private val mainScope = CoroutineScope(Discontextpatchers.Default)
 
-  private lateinit var  credentialManager: CredentialManager 
+    private val mainScope = CoroutineScope(Dispatchers.Default)
 
-  override fun definition() = ModuleDefinition {
-    Name("ReactNativePasskeys")
+    override fun definition() = ModuleDefinition {
+        Name("ReactNativePasskeys")
 
-    OnCreate {
-      credentialManager = CredentialManager.getInstance(appContext.reactContext)
+        Function("isSupported") {
+            val minApiLevelPasskeys = 28
+            val currentApiLevel = android.os.Build.VERSION.SDK_INT
+            return@Function currentApiLevel >= minApiLevelPasskeys
+        }
+
+        Function("isAutoFillAvailable") {
+            false
+        }
+
+        AsyncFunction("create") { request: PublicKeyCredentialCreationOptions, promise: Promise ->
+            val credentialManager = CredentialManager.create(appContext.reactContext?.applicationContext!!)
+            val json = Gson().toJson(request)
+            val createPublicKeyCredentialRequest = CreatePublicKeyCredentialRequest(json)
+
+            mainScope.launch {
+                try {
+                    val result = appContext.currentActivity?.let {
+                        credentialManager.createCredential(it, createPublicKeyCredentialRequest)
+                    }
+                    val response =
+                        result?.data?.getString("androidx.credentials.BUNDLE_KEY_REGISTRATION_RESPONSE_JSON")
+                    val createCredentialResponse = Gson().fromJson(response, RegistrationResponseJSON::class.java)
+                    promise.resolve(createCredentialResponse)
+                } catch (e: expo.modules.kotlin.exception.CodedException) {
+                    promise.reject(e)
+                }
+            }
+        }
+
+        AsyncFunction("get") { request: PublicKeyCredentialRequestOptions, promise: Promise ->
+            val credentialManager = CredentialManager.create(appContext.reactContext?.applicationContext!!)
+            val json = Gson().toJson(request)
+            val getCredentialRequest = GetCredentialRequest(listOf(GetPublicKeyCredentialOption(json)))
+
+            mainScope.launch {
+                try {
+                    val result = appContext.currentActivity?.let {
+                            credentialManager.getCredential(it, getCredentialRequest)
+                    }
+                    val response =
+                        result?.credential?.data?.getString("androidx.credentials.BUNDLE_KEY_AUTHENTICATION_RESPONSE_JSON")
+                    val createCredentialResponse = Gson().fromJson(response, AuthenticationResponseJSON::class.java)
+                    promise.resolve(createCredentialResponse)
+                } catch (e: expo.modules.kotlin.exception.CodedException) {
+                    promise.reject(e)
+                }
+            }
+        }
     }
-
-    Function("isSupported") {
-      "get world! 👋"
-    }
-
-    Function("isAutoFillAvailable") {
-      false
-    }
-
-    AsyncFunction("create") { request: String, promise: Promise ->
-      
-    }
-
-    AsyncFunction("get") { request: String, promise: Promise ->
-      launch(Dispatchers.Main) {
-        promise.resolve(request)
-      }
-    }
-  }
-
-  private fun createPasskey(request: String, promise: Promise ): String {
-    launch(Dispatchers.Main) {
-      
-
-
-
-
-      promise.resolve(request)
-    }
-  }
-
-  private fun getPasskey(request: String): String {}
 }

--- a/example/app.config.ts
+++ b/example/app.config.ts
@@ -7,38 +7,50 @@ const scheme = "react-native-passkeys";
 const bundleIdentifier = `${hostname.split(".").reverse().join(".")}.${scheme}`;
 
 const config = {
-	name: `${scheme}-example`,
-	slug: `${scheme}-example`,
-	owner: "peterferguson",
-	version: "1.0.0",
-	orientation: "portrait",
-	scheme,
-	icon: "./assets/icon.png",
-	userInterfaceStyle: "light",
-	splash: {
-		image: "./assets/splash.png",
-		resizeMode: "contain",
-		backgroundColor: "#ffffff",
-	},
-	assetBundlePatterns: ["**/*"],
-	ios: {
-		supportsTablet: true,
-		bundleIdentifier,
-		associatedDomains: [`applinks:${scheme}.${hostname}`, `webcredentials:${scheme}.${hostname}`],
-		infoPlist: { UIBackgroundModes: ["fetch", "remote-notification"] },
-	},
-	android: {
-		adaptiveIcon: {
-			foregroundImage: "./assets/adaptive-icon.png",
-			backgroundColor: "#ffffff",
-		},
-		package: bundleIdentifier,
-	},
-	web: {
-		bundler: "metro",
-		favicon: "./assets/favicon.png",
-	},
-	plugins: ["expo-router", ["expo-build-properties", { ios: { deploymentTarget: "15.0" } }]],
+  name: `${scheme}-example`,
+  slug: `${scheme}-example`,
+  owner: "peterferguson",
+  version: "1.0.0",
+  orientation: "portrait",
+  scheme,
+  icon: "./assets/icon.png",
+  userInterfaceStyle: "light",
+  splash: {
+    image: "./assets/splash.png",
+    resizeMode: "contain",
+    backgroundColor: "#ffffff",
+  },
+  assetBundlePatterns: ["**/*"],
+  ios: {
+    supportsTablet: true,
+    bundleIdentifier,
+    associatedDomains: [
+      `applinks:${scheme}.${hostname}`,
+      `webcredentials:${scheme}.${hostname}`,
+    ],
+    infoPlist: { UIBackgroundModes: ["fetch", "remote-notification"] },
+  },
+  android: {
+    adaptiveIcon: {
+      foregroundImage: "./assets/adaptive-icon.png",
+      backgroundColor: "#ffffff",
+    },
+    package: bundleIdentifier,
+  },
+  web: {
+    bundler: "metro",
+    favicon: "./assets/favicon.png",
+  },
+  plugins: [
+    "expo-router",
+    [
+      "expo-build-properties",
+      {
+        ios: { deploymentTarget: "15.0" },
+        android: { compileSdkVersion: 34 },
+      },
+    ],
+  ],
 } satisfies ExpoConfig;
 
 export default config;

--- a/example/public/.well-known/assetlinks.json
+++ b/example/public/.well-known/assetlinks.json
@@ -1,0 +1,10 @@
+[
+  {
+    "relation": ["delegate_permission/common.handle_all_urls"],
+    "target": {
+      "namespace": "android_app",
+      "package_name": "<package_name>",
+      "sha256_cert_fingerprints": ["<sha256_cert_fingerprint>"]
+    }
+  }
+]


### PR DESCRIPTION
Hey there. I added initial support for Android passkeys and some documentation. I've tested it and it seems to be working well. Let me know if you have any thoughts.

## Demo:
(Screen blacks out during biometrics scan)

https://github.com/peterferguson/react-native-passkeys/assets/29075740/fc41a4b7-1d75-49f1-a0dc-88bf405f2add

