### PR TITLE
feat: add support for RN 0.74 and expo sdk 51

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -54,19 +54,19 @@ android {
   compileSdkVersion safeExtGet("compileSdkVersion", 33)
 
   compileOptions {
-    sourceCompatibility JavaVersion.VERSION_11
-    targetCompatibility JavaVersion.VERSION_11
+    sourceCompatibility JavaVersion.VERSION_17
+    targetCompatibility JavaVersion.VERSION_17
   }
 
   def agpVersion = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION
   if (agpVersion.tokenize('.')[0].toInteger() < 8) {
     compileOptions {
-      sourceCompatibility JavaVersion.VERSION_11
-      targetCompatibility JavaVersion.VERSION_11
+      sourceCompatibility JavaVersion.VERSION_17
+      targetCompatibility JavaVersion.VERSION_17
     }
 
     kotlinOptions {
-      jvmTarget = JavaVersion.VERSION_11.majorVersion
+      jvmTarget = JavaVersion.VERSION_17.majorVersion
     }
   }
 


### PR DESCRIPTION
This PR addresses the following [issues](https://github.com/peterferguson/react-native-passkeys/issues/14 ) by updating the JAVA_VERSION to 17 as suggested [here](https://github.com/peterferguson/react-native-passkeys/issues/14#issuecomment-2235169962)

