### PR TITLE
fix: Prevent iOS Safari crash by passing undefined for empty largeBlob in credential requests

### DIFF
--- a/.changeset/tasty-ideas-accept.md
+++ b/.changeset/tasty-ideas-accept.md
@@ -1,0 +1,10 @@
+---
+"react-native-passkeys": patch
+---
+
+Fix iOS Safari crashing due to largeBlob empty object
+
+iOS Safari crashes when requesting a largeBlob credential with an empty object
+using the `get()` method.
+
+This patch passes undefined if the request does not include a largeBlob object.

--- a/src/ReactNativePasskeysModule.web.ts
+++ b/src/ReactNativePasskeysModule.web.ts
@@ -119,12 +119,12 @@ export default {
 					 * browsers that do not support the extension will just ignore the property so it's safe to include it
 					 *
 					 * @ts-expect-error:*/
-					largeBlob: {
-						...request.extensions?.largeBlob,
-						...(request.extensions?.largeBlob?.write && {
-							write: base64URLStringToBuffer(request.extensions.largeBlob.write),
-						}),
-					},
+					largeBlob: request.extensions?.largeBlob?.write
+						? {
+								...request.extensions?.largeBlob,
+								write: base64URLStringToBuffer(request.extensions.largeBlob.write),
+							}
+						: request.extensions?.largeBlob,
 				},
 				challenge: base64URLStringToBuffer(request.challenge),
 				allowCredentials: request.allowCredentials?.map((credential) => ({


### PR DESCRIPTION
Thanks for open-sourcing an awesome repo. I recently started replacing our homegrown solution with this modern Expo version.

However, I found that requesting credentials was causing iOS Safari to crash every time a `get()` was issued.

This patch makes the largeBlob pass an undefined if the caller does not specify it. You can see a screencap of the crash here.

https://github.com/user-attachments/assets/042ffddb-e7f4-4ef8-a28e-e5d1922d8890

Here is the repro in case you were wondering.

```js
let params = {
  rpId: 'localhost',
  challenge:
    '02NLGsT__qaHYgk9LXzeV5-ibvZ778EzfwlUcXbUWceKjjOdbLJVIzEoxyJhnD42-55zyuGSwP3GlvLb1XllGg',
  allowCredentials: [],
}

function base64URLStringToBuffer(base64URLString) {
  // Convert from Base64URL to Base64
  const base64 = base64URLString.replace(/-/g, '+').replace(/_/g, '/')
  /**
   * Pad with '=' until it's a multiple of four
   * (4 - (85 % 4 = 1) = 3) % 4 = 3 padding
   * (4 - (86 % 4 = 2) = 2) % 4 = 2 padding
   * (4 - (87 % 4 = 3) = 1) % 4 = 1 padding
   * (4 - (88 % 4 = 0) = 4) % 4 = 0 padding
   */
  const padLength = (4 - (base64.length % 4)) % 4
  const padded = base64.padEnd(base64.length + padLength, '=')

  // Convert to a binary string
  const binary = atob(padded)

  // Convert binary string to buffer
  const buffer = new ArrayBuffer(binary.length)
  const bytes = new Uint8Array(buffer)

  for (let i = 0; i < binary.length; i++) {
    bytes[i] = binary.charCodeAt(i)
  }

  return buffer
}

let repro = {
  mediation: undefined,
  signal: undefined,
  publicKey: {
    allowCredentials: [],
    challenge: base64URLStringToBuffer(params.challenge),
    extensions: { largeBlob: {} },
  },
  rpId: 'localhost',
}

// crashes here
navigator.credentials.get(repro).then(console.log).catch(console.error)
```