### PR TITLE
docs: Auto-translate README and Wiki

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,35 @@
+
+<div align="right">
+  <details>
+    <summary >🌐 Language</summary>
+    <div>
+      <div align="center">
+        <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=en">English</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=zh-CN">简体中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=zh-TW">繁體中文</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=ja">日本語</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=ko">한국어</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=hi">हिन्दी</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=th">ไทย</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=fr">Français</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=de">Deutsch</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=es">Español</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=it">Italiano</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=ru">Русский</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=pt">Português</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=nl">Nederlands</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=pl">Polski</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=ar">العربية</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=fa">فارسی</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=tr">Türkçe</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=vi">Tiếng Việt</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=id">Bahasa Indonesia</a>
+        | <a href="https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=as">অসমীয়া</
+      </div>
+    </div>
+  </details>
+</div>
+
 # React Native Passkeys
 
 This is an Expo module to help you create and authenticate with passkeys on iOS, Android & web with the same api. The library aims to stay close to the standard [`navigator.credentials`](https://w3c.github.io/webappsec-credential-management/#framework-credential-management). More specifically, we provide an api for `get` & `create` functions (since these are the functions available cross-platform).


### PR DESCRIPTION
Added language badges to the README for easier access to translated versions: German, Spanish, French, Japanese, Korean, Portuguese, and Russian 20 languages.
System will auto-update translation for README and Wiki when this repository updated, and support multiple languages google/bing SEO search.

Demo links : 
- [English](https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=en)
- [简体中文](https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=zh-CN)
- [日本語](https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=ja)
- [한국어](https://openaitx.github.io/view.html?user=peterferguson&project=react-native-passkeys&lang=ko)
..


<img width="1178" height="537" alt="Image" src="https://github.com/user-attachments/assets/7cd54a88-59c1-455f-9c7d-2db7f05b2962  " />

If this doesn't align with your expectations, feel free to close this PR. Thanks for your time! 🙌


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added a collapsible, right-aligned language selection dropdown at the top of the README, allowing users to quickly access documentation in multiple languages via direct links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->